### PR TITLE
Ocean error

### DIFF
--- a/demloader/download.py
+++ b/demloader/download.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from botocore import UNSIGNED
 from botocore.config import Config
 from osgeo import gdal
+from logger import logger
 import boto3
 
 def from_aws(prefixes, resolution, out_path='demloader_dem.tif'):
@@ -30,9 +31,12 @@ def from_aws(prefixes, resolution, out_path='demloader_dem.tif'):
     print(f"{len(prefixes)} DEM patches found for AOI. Ready for Download.")
     
     for prefix in prefixes:
-        object_path = str(temp_dir/f"{prefix}.tif")
-        aws_bucket.download_file(f"{prefix}/{prefix}.tif", object_path)
-        downloaded.append(str(object_path))
+        try:
+            object_path = str(temp_dir/f"{prefix}.tif")
+            aws_bucket.download_file(f"{prefix}/{prefix}.tif", object_path)
+            downloaded.append(str(object_path))
+        except:
+            logger.exception(f'Error when downloading prefix {prefix}')
 
     if len(downloaded) >= 1:
         gdal.BuildVRT(str(vrt_path), downloaded, options=gdal.BuildVRTOptions())

--- a/demloader/download.py
+++ b/demloader/download.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from botocore import UNSIGNED
 from botocore.config import Config
 from osgeo import gdal
-from logger import logger
+from demloader.logger import logger
 import boto3
 
 def from_aws(prefixes, resolution, out_path='demloader_dem.tif'):
@@ -36,7 +36,7 @@ def from_aws(prefixes, resolution, out_path='demloader_dem.tif'):
             aws_bucket.download_file(f"{prefix}/{prefix}.tif", object_path)
             downloaded.append(str(object_path))
         except:
-            logger.exception(f'Error when downloading prefix {prefix}')
+            logger.error(f'Error when downloading prefix {prefix}. Download skipped.')
 
     if len(downloaded) >= 1:
         gdal.BuildVRT(str(vrt_path), downloaded, options=gdal.BuildVRTOptions())

--- a/demloader/logger.py
+++ b/demloader/logger.py
@@ -1,0 +1,6 @@
+import logging
+
+logger = logging
+logger.basicConfig(format='[%(levelname)s] %(asctime)s - %(message)s', 
+                   datefmt='%Y-%m-%d %H:%M:%S',
+                   level=logging.INFO)


### PR DESCRIPTION
Error in `download.py` catched and logged.

Does not distinguish type of error but is intended to mainly catch 404 error when DEM data is pulled over oceans where no data exists.